### PR TITLE
Button to load more recipes added

### DIFF
--- a/back-end/app.js
+++ b/back-end/app.js
@@ -257,7 +257,7 @@ app.get('/feedrecipes', (req, res, next) => {
         createdAt: { $gt: twoWeeksAgo },
 
         // make sure a recipe's user's id is one that is one being followed
-        'user._id': { $in: followingList }
+        user: { $in: followingList }
     })
         .sort({ createdAt: -1 }) // Reverse the order of creation dates so latest recipe is on top
         .then((recipes) => res.json(recipes))

--- a/back-end/app.js
+++ b/back-end/app.js
@@ -254,10 +254,10 @@ app.get('/feedrecipes', (req, res, next) => {
 
     Recipe.find({
         // make sure recipe's creation date is within the last two weeks
-        createdAt: { $gt: twoWeeksAgo }, // Dev note: This works -- Successfully lists all recipes made within last two weeks
+        createdAt: { $gt: twoWeeksAgo },
 
         // make sure a recipe's user's id is one that is one being followed
-        'user.id': { $in: followingList }
+        'user._id': { $in: followingList }
     })
         .sort({ createdAt: -1 }) // Reverse the order of creation dates so latest recipe is on top
         .then((recipes) => res.json(recipes))

--- a/front-end/src/FeedPage.css
+++ b/front-end/src/FeedPage.css
@@ -1,3 +1,10 @@
 .feed-entry {
     margin: 5%;
 }
+
+.recLoadedText {
+    text-align: center;
+    color: rgb(23, 162, 184);
+    font-size: 14px;
+    margin-bottom: 4px;
+}

--- a/front-end/src/FeedPage.js
+++ b/front-end/src/FeedPage.js
@@ -104,7 +104,7 @@ const Feed = (props) => {
                     id="loadMoreRecipesBtn"
                     onClick={loadMoreRecipes}
                 >
-                    Load More Recipes
+                    Load Older Recipes
                 </Button>
             </div>
         </>


### PR DESCRIPTION
- Added button to load more recipes. Currently does every 2 weeks as a base concept. Potential "algorithm" could be based on number of followers and/or number of recipes loaded.
- Re-queries the database with a longer date and scroll location is maintained, so no need for concatenation of a new date window
<img src="https://user-images.githubusercontent.com/12663558/115050209-84d2c800-9ea9-11eb-892e-4f56236cae8b.gif" height=600px>

- ~~Due to undergoing database schema changes, I've updated the back-end to pull `user._id` but the line boxed in red needs to be commented out to test this~~
<img src="https://user-images.githubusercontent.com/12663558/115050455-c5324600-9ea9-11eb-96b2-bf9a637384d9.png" width=4px>

resolves #374 