### PR TITLE
Reword and add link to feed page on Error Component

### DIFF
--- a/front-end/src/gencomponents/ErrorComponent.css
+++ b/front-end/src/gencomponents/ErrorComponent.css
@@ -7,10 +7,16 @@
 
 .errorComponentString {
     color: gray;
-    margin:30px;
+    margin: 30px;
+}
+.errorComponentLink:link,
+.errorComponentLink:active,
+.errorComponentLink:visited,
+.errorComponentLink:hover {
+    color: rgb(23, 162, 184);
 }
 
 .errorComponentIcon {
     font-size: 100px;
-    color:rgb(23, 162, 184)
+    color: rgb(23, 162, 184);
 }

--- a/front-end/src/gencomponents/ErrorComponent.js
+++ b/front-end/src/gencomponents/ErrorComponent.js
@@ -4,20 +4,24 @@ import { EmojiFrown } from 'react-bootstrap-icons'
 
 // props.error is a string that CAN be passed in to customize the error message
 const ErrorComponent = (props) => {
-
     // Declare error message for component if none is given
-    let errorString = props.error || "Sorry, something went wrong!"
+    let errorString =
+        props.error ||
+        'Looks like something went wrong! This page may be broken, or it may have been removed. '
 
     return (
         <div className="errorComponentContainer">
+            <EmojiFrown className="errorComponentIcon" />
 
-            <EmojiFrown className ="errorComponentIcon" />
-
-            <p className="errorComponentString">{errorString}</p>
-
+            <p className="errorComponentString">
+                {errorString}
+                <a className="errorComponentLink" href="/feed">
+                    Return to feed page
+                </a>
+                .
+            </p>
         </div>
     )
-
 }
 
 export default ErrorComponent


### PR DESCRIPTION
- The default message for `<ErrorComponent>` has been reworded
- Regardless of message, a link to return to the feed page will be shown
![image](https://user-images.githubusercontent.com/12663558/115906346-66367900-a435-11eb-8fc1-297d03c26a1d.png)
