### PR TITLE
Multiple Image support

### DIFF
--- a/back-end/app.js
+++ b/back-end/app.js
@@ -697,16 +697,21 @@ const updateTags = (tags, i, cb, next) => {
 
 app.post(
     '/newrecipe',
-    upload.single('recipeimage'),
+    upload.array('recipeimage', 5),
     // sanitize recipe inputs -- text fields since that's what the user has control over
     body('name').not().isEmpty().trim().escape(),
     body('caption').not().isEmpty().trim().escape(),
     (req, res, next) => {
+        console.log(req.files) // hopefully i remember to remove this
         // new recipe
         const newRecipe = {
             user: req.body.userID,
             name: req.body.name,
-            imagePath: path.join('/uploads/', req.file.filename),
+            // imagePath: path.join('/uploads/', req.file.filename),
+            imagePath: req.files.forEach((file) => {
+                console.log(file.filename)
+                path.join('/uploads/', file.filename)
+            }),
             tags: JSON.parse(req.body.tags).filter((tag) => tag !== ''),
             caption: req.body.caption,
             ingredients: JSON.parse(req.body.ingredients)
@@ -721,6 +726,8 @@ app.post(
             likes: 0,
             createdAt: Date.now()
         }
+
+        console.log('imgPath:' + newRecipe.imagePath) // hopefully i remember to remove this
 
         // save new recipe to database
         new Recipe(newRecipe)

--- a/back-end/app.js
+++ b/back-end/app.js
@@ -708,10 +708,9 @@ app.post(
             user: req.body.userID,
             name: req.body.name,
             // imagePath: path.join('/uploads/', req.file.filename),
-            imagePath: req.files.forEach((file) => {
-                console.log(file.filename)
+            imagePath: req.files.map((file) =>
                 path.join('/uploads/', file.filename)
-            }),
+            ),
             tags: JSON.parse(req.body.tags).filter((tag) => tag !== ''),
             caption: req.body.caption,
             ingredients: JSON.parse(req.body.ingredients)

--- a/back-end/app.js
+++ b/back-end/app.js
@@ -702,12 +702,10 @@ app.post(
     body('name').not().isEmpty().trim().escape(),
     body('caption').not().isEmpty().trim().escape(),
     (req, res, next) => {
-        console.log(req.files) // hopefully i remember to remove this
         // new recipe
         const newRecipe = {
             user: req.body.userID,
             name: req.body.name,
-            // imagePath: path.join('/uploads/', req.file.filename),
             imagePath: req.files.map((file) =>
                 path.join('/uploads/', file.filename)
             ),
@@ -725,8 +723,6 @@ app.post(
             likes: 0,
             createdAt: Date.now()
         }
-
-        console.log('imgPath:' + newRecipe.imagePath) // hopefully i remember to remove this
 
         // save new recipe to database
         new Recipe(newRecipe)

--- a/back-end/db.js
+++ b/back-end/db.js
@@ -32,7 +32,7 @@ User.plugin(URLSlugs('username', { field: 'slug' }))
 const Recipe = new mongoose.Schema({
     user: { type: mongoose.Schema.Types.ObjectId, ref: 'User' },
     name: { type: String, required: true },
-    imagePath: { type: String, required: true },
+    imagePath: { type: [String], required: true },
     tags: [String],
     caption: { type: String },
     ingredients: [String],

--- a/front-end/src/pages/recipepages/components/LargeRecipePreview.js
+++ b/front-end/src/pages/recipepages/components/LargeRecipePreview.js
@@ -62,7 +62,7 @@ const LargeRecipePreview = (props) => {
             >
                 <img
                     className="largeRecipePreviewImage"
-                    src={process.env.PUBLIC_URL + props.recipe.imagePath}
+                    src={process.env.PUBLIC_URL + props.recipe.imagePath[0]}
                     alt="food"
                 />
                 <table className="largeRecipePreviewTable largeRecipePreviewTopTable">

--- a/front-end/src/pages/recipepages/components/SmallRecipePreview.js
+++ b/front-end/src/pages/recipepages/components/SmallRecipePreview.js
@@ -76,7 +76,7 @@ const SmallRecipePreview = (props) => {
                                             ? ''
                                             : ' smallRecipePreviewImageExpanded'
                                     }`}
-                                    src={props.recipe.imagePath}
+                                    src={props.recipe.imagePath[0]}
                                     alt="food"
                                 />
                             </td>

--- a/front-end/src/pages/recipepages/newrecipe/NewRecipePage.js
+++ b/front-end/src/pages/recipepages/newrecipe/NewRecipePage.js
@@ -20,7 +20,7 @@ const NewRecipePage = (props) => {
     const [tags, setTags] = useState([])
     const [ingredientValues, setIngredientValues] = useState([''])
     const [instructionValues, setInstructionValues] = useState([''])
-    const [imageFile, setImageFile] = useState()
+    const [imageFile, setImageFile] = useState([''])
 
     // state variables for disabling post recipe button
     const [emptyField, setEmptyField] = useState(true)
@@ -47,7 +47,12 @@ const NewRecipePage = (props) => {
         const newRecipe = new FormData()
         newRecipe.append('userID', props.user._id)
         newRecipe.append('name', nameValue)
-        newRecipe.append('recipeimage', imageFile)
+        console.log(imageFile)
+        imageFile.forEach((image) => {
+            newRecipe.append('recipeimage[]', image)
+        })
+        console.log(newRecipe.recipeimage)
+        newRecipe.append('recipeimage', JSON.stringify(imageFile))
         newRecipe.append('tags', JSON.stringify(tags))
         newRecipe.append('caption', captionValue)
         newRecipe.append('ingredients', JSON.stringify(ingredientValues))
@@ -89,6 +94,12 @@ const NewRecipePage = (props) => {
         setTags(tags.slice(0, i).concat(tags.slice(i + 1)))
     }
 
+    // REMOVED FOR CROPPING?
+    useEffect(() => {
+        bsCustomFileInput.init()
+    }, [])
+    // END OF WHAT WAS REMOVED FOR CROPPING
+
     // check for empty fields
     useEffect(() => {
         setEmptyField(
@@ -112,8 +123,9 @@ const NewRecipePage = (props) => {
 
     const fileUploaded = (event) => {
         setUploadedImage(event.target.value !== '')
-        setImageFile(event.target.files[0])
+        setImageFile(event.target.files)
 
+        /* STUFF FOR CROPPING
         const recipeimgForCropperJS = document.querySelector('img')
         const file = event.target.files[0]
 
@@ -135,6 +147,8 @@ const NewRecipePage = (props) => {
         } else {
             setShowModal(false)
         }
+
+        END OF STUFF FOR CROPPING */
     }
 
     return !submitted ? (
@@ -233,7 +247,8 @@ const NewRecipePage = (props) => {
                 <Form.Group controlId="formRecipeImage">
                     <Form.File
                         id="custom-file"
-                        label="Upload recipe image"
+                        label="Upload recipe image (max. 5)"
+                        multiple
                         onChange={fileUploaded}
                         onClick={clearUpload}
                         custom
@@ -253,7 +268,7 @@ const NewRecipePage = (props) => {
 
                 {/*to send to cropper modal*/}
                 <img id="img" alt="" />
-
+                {/* Need to implement cropping for all images once it works without that
                 <ImageCropModal
                     bsCustomFileInput={bsCustomFileInput}
                     setImgForUpload={setImageFile}
@@ -261,7 +276,7 @@ const NewRecipePage = (props) => {
                     imgsrc={recipeImgSrc}
                     show={showModal}
                     setShow={setShowModal}
-                />
+                /> */}
             </Form>
         </div>
     ) : (

--- a/front-end/src/pages/recipepages/newrecipe/NewRecipePage.js
+++ b/front-end/src/pages/recipepages/newrecipe/NewRecipePage.js
@@ -20,7 +20,7 @@ const NewRecipePage = (props) => {
     const [tags, setTags] = useState([])
     const [ingredientValues, setIngredientValues] = useState([''])
     const [instructionValues, setInstructionValues] = useState([''])
-    const [imageFile, setImageFile] = useState([''])
+    const [imageFiles, setImageFiles] = useState([''])
 
     // state variables for disabling post recipe button
     const [emptyField, setEmptyField] = useState(true)
@@ -47,12 +47,9 @@ const NewRecipePage = (props) => {
         const newRecipe = new FormData()
         newRecipe.append('userID', props.user._id)
         newRecipe.append('name', nameValue)
-        console.log(imageFile)
-        imageFile.forEach((image) => {
-            newRecipe.append('recipeimage[]', image)
-        })
-        console.log(newRecipe.recipeimage)
-        newRecipe.append('recipeimage', JSON.stringify(imageFile))
+        for (let i = 0; i < imageFiles.length; i++) {
+            newRecipe.append('recipeimage', imageFiles[i])
+        }
         newRecipe.append('tags', JSON.stringify(tags))
         newRecipe.append('caption', captionValue)
         newRecipe.append('ingredients', JSON.stringify(ingredientValues))
@@ -123,7 +120,7 @@ const NewRecipePage = (props) => {
 
     const fileUploaded = (event) => {
         setUploadedImage(event.target.value !== '')
-        setImageFile(event.target.files)
+        setImageFiles(event.target.files)
 
         /* STUFF FOR CROPPING
         const recipeimgForCropperJS = document.querySelector('img')
@@ -271,7 +268,7 @@ const NewRecipePage = (props) => {
                 {/* Need to implement cropping for all images once it works without that
                 <ImageCropModal
                     bsCustomFileInput={bsCustomFileInput}
-                    setImgForUpload={setImageFile}
+                    setImgForUpload={setImageFiles}
                     setUploadedImage={setUploadedImage}
                     imgsrc={recipeImgSrc}
                     show={showModal}


### PR DESCRIPTION
Part 1 of 2 of a larger change for #465 

- Database schema updated so that `imagePath` is now an array of strings, not a single string
- Can select up to 5 images on the front-end
- Single images on large/small previews + recipepage now use `image[0]` until database is updated
